### PR TITLE
Improve solver speed

### DIFF
--- a/packages/web/src/lib/white-cross-solver.ts
+++ b/packages/web/src/lib/white-cross-solver.ts
@@ -3,11 +3,22 @@ import {
   CubieMoveNotation,
   CubieState,
 } from "../types/cubie";
+import { CubeColor, CubeFace } from "../types/cube-core";
 import {
   copyCubieState,
   executeSolverMove,
+  executeSolverMoveSequence,
   getCubieDisplayColor,
 } from "./cubie-utils";
+
+const COLOR_TO_FACE: Record<CubeColor, CubeFace> = {
+  red: 'front',
+  orange: 'back',
+  green: 'left',
+  blue: 'right',
+  white: 'top',
+  yellow: 'bottom',
+};
 
 /**
  * Represents a white edge piece and its current state
@@ -22,28 +33,14 @@ interface WhiteEdge {
 /**
  * Maps edge colors to their target positions on the white face (top layer, y=2)
  */
-/**
- * Represents a node in the BFS search graph
- */
-interface GraphNode {
-  stateHash: string;
-  moves: CubieMoveNotation[];
-  depth: number;
-}
 
 /**
- * White Cross Solver for 3x3 Rubik's Cube
- * Implements a proper graph-based BFS algorithm
- * Nodes = cube states (hashed by white edge positions/orientations)
- * Edges = moves that transition between states
- * Target = solved white cross state
+ * White Cross Solver for 3x3 Rubik's Cube.
+ * Uses a straightforward heuristic approach to insert each white edge
+ * into its correct position without an exhaustive search.
  */
 export class WhiteCrossSolver {
   private initialState: CubieState;
-  private visitedStates = new Map<string, CubieMoveNotation[]>(); // stateHash -> moves to reach this state
-  private fundamentalMoves: CubieMoveNotation[] = [
-    'R', "R'", 'U', "U'", 'L', "L'", 'F', "F'", 'B', "B'", 'D', "D'"
-  ];
   private targetStateHash: string;
 
   constructor(initialState: CubieState) {
@@ -65,144 +62,30 @@ export class WhiteCrossSolver {
   }
 
   /**
-   * Solves the white cross using optimized graph-based BFS
+   * Solves the white cross using a simple heuristic approach.
    */
   solve(): CubieMoveNotation[] {
-    const startState = copyCubieState(this.initialState);
-    const startHash = this.hashWhiteCrossState(startState);
-    
-    // Check if already solved
-    if (startHash === this.targetStateHash) {
-      return [];
+    let state = copyCubieState(this.initialState);
+    const solution: CubieMoveNotation[] = [];
+
+    let iterations = 0;
+    while (this.hashWhiteCrossState(state) !== this.targetStateHash && iterations < 10) {
+      const edges = this.findWhiteEdges(state);
+      for (const edge of edges) {
+        if (edge.isSolved) continue;
+        state = this.solveEdge(edge.cubie, state, solution);
+      }
+      iterations++;
     }
 
-    // BFS queue: each node represents a cube state
-    const queue: GraphNode[] = [{
-      stateHash: startHash,
-      moves: [],
-      depth: 0
-    }];
-    
-    // Track visited states and the moves to reach them
-    this.visitedStates.set(startHash, []);
-    
-    const maxDepth = 12; // Increased to handle 8-move solutions
-    let nodesExplored = 0;
-    const maxNodes = 50000; // Increased node limit
-    
-    while (queue.length > 0 && nodesExplored < maxNodes) {
-      const currentNode = queue.shift()!;
-      nodesExplored++;
-      
-      // Skip if we've gone too deep
-      if (currentNode.depth >= maxDepth) {
-        continue;
-      }
-      
-      // Get valid moves (avoiding inverse of last move and redundant sequences)
-      const validMoves = this.getValidMoves(currentNode.moves);
-      
-      // Prioritize moves that might help with white cross (bottom and top face moves first)
-      const prioritizedMoves = this.prioritizeMovesForWhiteCross(validMoves);
-      
-      for (const move of prioritizedMoves) {
-        // Apply move to get new state
-        const currentState = this.stateFromHash(currentNode.stateHash, startState, currentNode.moves);
-        const newState = executeSolverMove(currentState, move);
-        const newHash = this.hashWhiteCrossState(newState);
-        
-        // Skip if we've seen this state before (loop prevention)
-        if (this.visitedStates.has(newHash)) {
-          continue;
-        }
-        
-        const newMoves = [...currentNode.moves, move];
-        
-        // Check if this is the target state (solved white cross)
-        if (newHash === this.targetStateHash) {
-          return newMoves;
-        }
-        
-        // Add to visited states and queue for further exploration
-        this.visitedStates.set(newHash, newMoves);
-        queue.push({
-          stateHash: newHash,
-          moves: newMoves,
-          depth: currentNode.depth + 1
-        });
-      }
+    if (this.hashWhiteCrossState(state) === this.targetStateHash) {
+      return solution;
     }
-    
-    // Try a fallback approach with a different strategy
+
+    // Fallback to the old simple sequences if our heuristics failed
     return this.fallbackSolve();
   }
 
-  /**
-   * Gets valid moves, excluding inverses of the last move and redundant sequences
-   */
-  private getValidMoves(previousMoves: CubieMoveNotation[]): CubieMoveNotation[] {
-    if (previousMoves.length === 0) {
-      return [...this.fundamentalMoves];
-    }
-    
-    const lastMove = previousMoves[previousMoves.length - 1];
-    const lastFace = lastMove.charAt(0);
-    
-    // Filter out moves that would be redundant or counterproductive
-    return this.fundamentalMoves.filter(move => {
-      const currentFace = move.charAt(0);
-      
-      // Don't do the inverse of the last move (immediate backtracking)
-      if (move === this.getInverseMove(lastMove)) {
-        return false;
-      }
-      
-      // Don't do the same face move consecutively more than 3 times
-      if (currentFace === lastFace && previousMoves.length >= 2) {
-        const secondLastMove = previousMoves[previousMoves.length - 2];
-        const secondLastFace = secondLastMove.charAt(0);
-        if (secondLastFace === lastFace) {
-          return false; // Already did this face twice in a row
-        }
-      }
-      
-      return true;
-    });
-  }
-
-  /**
-   * Gets the inverse of a move (e.g., R -> R', R' -> R)
-   */
-  private getInverseMove(move: CubieMoveNotation): CubieMoveNotation {
-    const inverseMoves: Record<CubieMoveNotation, CubieMoveNotation> = {
-      'R': "R'",
-      "R'": 'R',
-      'U': "U'",
-      "U'": 'U',
-      'L': "L'",
-      "L'": 'L',
-      'F': "F'",
-      "F'": 'F',
-      'B': "B'",
-      "B'": 'B',
-      'D': "D'",
-      "D'": 'D'
-    };
-    
-    return inverseMoves[move];
-  }
-
-  /**
-   * Prioritizes moves that are more likely to help solve the white cross
-   */
-  private prioritizeMovesForWhiteCross(moves: CubieMoveNotation[]): CubieMoveNotation[] {
-    // Prioritize bottom face moves (D, D') and top face moves (U, U') as they're most relevant for white cross
-    const priority1 = moves.filter(move => move.startsWith('D') || move.startsWith('U'));
-    const priority2 = moves.filter(move => move.startsWith('F') || move.startsWith('B'));
-    const priority3 = moves.filter(move => move.startsWith('R') || move.startsWith('L'));
-    
-    return [...priority1, ...priority2, ...priority3];
-  }
 
   /**
    * Fallback solver using a simpler approach if BFS fails
@@ -238,14 +121,85 @@ export class WhiteCrossSolver {
     return [];
   }
 
-  /**
-   * Reconstructs a cube state from a hash and move sequence
-   */
-  private stateFromHash(_hash: string, startState: CubieState, moves: CubieMoveNotation[]): CubieState {
-    let state = copyCubieState(startState);
-    for (const move of moves) {
-      state = executeSolverMove(state, move);
+  /** Gets the face that currently contains the white sticker */
+  private getWhiteStickerFace(cubie: Cubie): CubeFace | null {
+    const faces: CubeFace[] = ['front', 'back', 'left', 'right', 'top', 'bottom'];
+    for (const face of faces) {
+      if (getCubieDisplayColor(cubie, face, 3) === 'white') {
+        return face;
+      }
     }
+    return null;
+  }
+
+  /** Gets the non-white sticker face and color for an edge */
+  private getOtherSticker(cubie: Cubie): { face: CubeFace; color: CubeColor } {
+    const faces: CubeFace[] = ['front', 'back', 'left', 'right', 'top', 'bottom'];
+    for (const face of faces) {
+      const color = getCubieDisplayColor(cubie, face, 3);
+      if (color && color !== 'white') {
+        return { face, color };
+      }
+    }
+    // Fallback - shouldn't happen
+    return { face: 'front', color: 'red' };
+  }
+
+  private colorToFace(color: CubeColor): CubeFace {
+    return COLOR_TO_FACE[color];
+  }
+
+  private getCubieById(state: CubieState, id: number): Cubie {
+    const cubie = state.cubies.find(c => c.id === id);
+    if (!cubie) {
+      throw new Error('Cubie not found');
+    }
+    return cubie;
+  }
+
+  /** Inserts a single white edge using simple moves */
+  private solveEdge(cubie: Cubie, state: CubieState, moves: CubieMoveNotation[]): CubieState {
+    let workingCubie = this.getCubieById(state, cubie.id);
+    let whiteFace = this.getWhiteStickerFace(workingCubie);
+    let other = this.getOtherSticker(workingCubie);
+
+    const moveMap: Record<CubeFace, string> = {
+      front: 'F',
+      back: 'B',
+      left: 'L',
+      right: 'R',
+      top: 'U',
+      bottom: 'D',
+    };
+
+    let guard = 0;
+    while (whiteFace !== 'bottom' && guard < 6) {
+      const m = moveMap[whiteFace!];
+      const seq: CubieMoveNotation[] = [m, 'D', `${m}'`];
+      state = executeSolverMoveSequence(state, seq);
+      moves.push(...seq);
+      workingCubie = this.getCubieById(state, cubie.id);
+      whiteFace = this.getWhiteStickerFace(workingCubie);
+      other = this.getOtherSticker(workingCubie);
+      guard++;
+    }
+
+    if (whiteFace === 'bottom') {
+      const targetFace = this.colorToFace(other.color);
+      while (other.face !== targetFace && guard < 10) {
+        state = executeSolverMove(state, 'D');
+        moves.push('D');
+        workingCubie = this.getCubieById(state, cubie.id);
+        other = this.getOtherSticker(workingCubie);
+        guard++;
+      }
+
+      const faceMove = moveMap[targetFace];
+      const doubleMove = `${faceMove}2` as CubieMoveNotation;
+      state = executeSolverMove(state, doubleMove);
+      moves.push(doubleMove);
+    }
+
     return state;
   }
 


### PR DESCRIPTION
## Summary
- remove BFS-based strategy for white cross solution
- use heuristic solver for faster results

## Testing
- `yarn test:run` *(fails: No test files found)*
- `yarn lint` *(fails: 6 errors)*
- `yarn workspace rcube-js-web build`

------
https://chatgpt.com/codex/tasks/task_e_6883bc5483c883309b6e8f36e8f3fc90